### PR TITLE
refactor: derive system prompt snippets from custom commands

### DIFF
--- a/packages/core/src/chat/app-adapter.ts
+++ b/packages/core/src/chat/app-adapter.ts
@@ -1,7 +1,12 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import type { SkillMeta, StorageNamespace } from "@office-agents/sdk";
-import type { CustomCommand } from "just-bash/browser";
+import type {
+  CustomCommandsResult,
+  SkillMeta,
+  StorageNamespace,
+} from "@office-agents/sdk";
 import type { Component } from "svelte";
+
+export type { CustomCommandsResult };
 
 export type MaybePromise<T> = T | Promise<T>;
 
@@ -21,7 +26,7 @@ export interface ToolExtrasProps {
 
 export interface AppAdapter {
   tools: AgentTool[];
-  buildSystemPrompt: (skills: SkillMeta[]) => string;
+  buildSystemPrompt: (skills: SkillMeta[], commandSnippets: string[]) => string;
   getDocumentId: () => Promise<string>;
   getDocumentMetadata?: () => Promise<{
     metadata: object;
@@ -34,7 +39,7 @@ export interface AppAdapter {
   appName?: string;
   emptyStateMessage?: string;
   staticFiles?: Record<string, string>;
-  customCommands?: () => CustomCommand[];
+  customCommands?: () => CustomCommandsResult;
   hasImageSearch?: boolean;
   showFollowModeToggle?: boolean;
   handleLinkClick?: (

--- a/packages/core/src/chat/index.ts
+++ b/packages/core/src/chat/index.ts
@@ -3,7 +3,11 @@ export type {
   MessagePart,
   ToolCallStatus,
 } from "@office-agents/sdk";
-export type { AppAdapter, ToolExtrasProps } from "./app-adapter";
+export type {
+  AppAdapter,
+  CustomCommandsResult,
+  ToolExtrasProps,
+} from "./app-adapter";
 export { default as ChatInterface } from "./chat-interface.svelte";
 export { getChatContext } from "./chat-runtime-context";
 export { default as FilesPanel } from "./files-panel.svelte";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export {
   getOrCreateDocumentId,
   getSession,
   getSessionMessageCount,
+  type DescribedCommand,
   getSharedCustomCommands,
   getVfs,
   type ImageSearchOptions,
@@ -123,6 +124,7 @@ export {
 export type {
   AppAdapter,
   ChatTab,
+  CustomCommandsResult,
   ToolExtrasProps,
 } from "./chat";
 export { ChatInterface, FilesPanel, getChatContext } from "./chat";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   // Truncation
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
+  type DescribedCommand,
   defineTool,
   // VFS
   deleteFile,
@@ -49,7 +50,6 @@ export {
   getOrCreateDocumentId,
   getSession,
   getSessionMessageCount,
-  type DescribedCommand,
   getSharedCustomCommands,
   getVfs,
   type ImageSearchOptions,

--- a/packages/excel/CHANGELOG.md
+++ b/packages/excel/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Co-located command prompt snippets** — Excel-specific VFS commands (`csv-to-sheet`, `sheet-to-csv`, `image-to-sheet`) now use `DescribedCommand` with co-located `promptSnippet`. System prompt assembles command docs dynamically from snippets instead of hard-coding them.
+
 ## [0.2.8] - 2026-03-19
 
 ### Changed

--- a/packages/excel/src/lib/system-prompt.ts
+++ b/packages/excel/src/lib/system-prompt.ts
@@ -1,6 +1,10 @@
 import { buildSkillsPromptSection, type SkillMeta } from "@office-agents/core";
 
-export function buildExcelSystemPrompt(skills: SkillMeta[]): string {
+export function buildExcelSystemPrompt(
+  skills: SkillMeta[],
+  commandSnippets: string[] = [],
+): string {
+  const customCommandsList = commandSnippets.map((s) => `  ${s}`).join("\n");
   return `You are an AI assistant integrated into Microsoft Excel with full access to read and modify spreadsheet data.
 
 ## Office.js API Reference
@@ -16,16 +20,7 @@ FILES & SHELL:
   Supports: ls, cat, grep, find, awk, sed, jq, sort, uniq, wc, cut, head, tail, etc.
 
   Custom commands for efficient data transfer (data flows directly, never enters your context):
-  - csv-to-sheet <file> <sheetId> [startCell] [--force] — Import CSV from VFS into spreadsheet. Auto-detects types.
-    Fails if target cells already have data. Use --force to overwrite (confirm with user first).
-  - sheet-to-csv <sheetId> [range] [file] — Export range to CSV. Defaults to full used range if no range given. Prints to stdout if no file given (pipeable).
-  - pdf-to-text <file> <outfile> — Extract text from PDF to file. Use head/grep/tail to read selectively.
-  - pdf-to-images <file> <outdir> [--scale=N] [--pages=1,3,5-8] — Render PDF pages to PNG images. Use for scanned PDFs where text extraction won't work. Then use read to visually inspect the images.
-  - docx-to-text <file> <outfile> — Extract text from DOCX to file.
-  - xlsx-to-csv <file> <outfile> [sheet] — Convert XLSX/XLS/ODS sheet to CSV. Sheet by name or 0-based index.
-  - image-to-sheet <file> <width> <height> <sheetId> [startCell] [--cell-size=N] — Render an image as pixel art in Excel. Downsamples to target size and paints cell backgrounds. Cell size in points (default: 3). Max 500×500. Example: image-to-sheet uploads/logo.png 64 64 1 A1 --cell-size=4
-  - web-search <query> [--max=N] [--region=REGION] [--time=d|w|m|y] [--page=N] [--json] — Search the web. Returns title, URL, and snippet for each result.
-  - web-fetch <url> <outfile> — Fetch a web page and extract its readable content to a file. Use head/grep/tail to read selectively.
+${customCommandsList}
 
   Examples:
     csv-to-sheet uploads/data.csv 1 A1       # import CSV to sheet 1

--- a/packages/excel/src/lib/vfs/custom-commands.ts
+++ b/packages/excel/src/lib/vfs/custom-commands.ts
@@ -1,5 +1,8 @@
-import { getSharedCustomCommands } from "@office-agents/core";
-import type { Command, CustomCommand } from "just-bash/browser";
+import {
+  getSharedCustomCommands,
+  type CustomCommandsResult,
+  type DescribedCommand,
+} from "@office-agents/core";
 import { defineCommand } from "just-bash/browser";
 import type { CellInput } from "../excel/api";
 import { getRangeAsCsv, getWorksheetById, setCellRange } from "../excel/api";
@@ -21,73 +24,77 @@ export {
   rgbToHex,
 } from "./command-utils";
 
-const csvToSheet: Command = defineCommand("csv-to-sheet", async (args, ctx) => {
-  // Extract flags
-  const force = args.includes("--force") || args.includes("-f");
-  const positional = args.filter((a) => a !== "--force" && a !== "-f");
+const csvToSheet: DescribedCommand = {
+  promptSnippet:
+    "- csv-to-sheet <file> <sheetId> [startCell] [--force] — Import CSV from VFS into spreadsheet. Auto-detects types.\n    Fails if target cells already have data. Use --force to overwrite (confirm with user first).",
+  command: defineCommand("csv-to-sheet", async (args, ctx) => {
+    // Extract flags
+    const force = args.includes("--force") || args.includes("-f");
+    const positional = args.filter((a) => a !== "--force" && a !== "-f");
 
-  if (positional.length < 2) {
-    return {
-      stdout: "",
-      stderr:
-        "Usage: csv-to-sheet <file> <sheetId> [startCell] [--force]\n  file      - Path to CSV file in VFS\n  sheetId   - Target sheet ID (number)\n  startCell - Top-left cell, default A1\n  --force   - Overwrite existing cell data\n",
-      exitCode: 1,
-    };
-  }
-
-  const [filePath, sheetIdStr, startCell = "A1"] = positional;
-  const sheetId = Number.parseInt(sheetIdStr, 10);
-  if (Number.isNaN(sheetId)) {
-    return {
-      stdout: "",
-      stderr: `Invalid sheetId: ${sheetIdStr}`,
-      exitCode: 1,
-    };
-  }
-
-  const upperStartCell = startCell.toUpperCase();
-  if (!/^[A-Z]+\d+$/.test(upperStartCell)) {
-    return {
-      stdout: "",
-      stderr: `Invalid start cell: ${startCell}`,
-      exitCode: 1,
-    };
-  }
-
-  try {
-    const resolvedPath = filePath.startsWith("/")
-      ? filePath
-      : `${ctx.cwd}/${filePath}`;
-    const content = await ctx.fs.readFile(resolvedPath);
-    const rows = parseCsv(content);
-
-    if (rows.length === 0) {
-      return { stdout: "", stderr: "CSV file is empty", exitCode: 1 };
+    if (positional.length < 2) {
+      return {
+        stdout: "",
+        stderr:
+          "Usage: csv-to-sheet <file> <sheetId> [startCell] [--force]\n  file      - Path to CSV file in VFS\n  sheetId   - Target sheet ID (number)\n  startCell - Top-left cell, default A1\n  --force   - Overwrite existing cell data\n",
+        exitCode: 1,
+      };
     }
 
-    // Normalize column count (pad shorter rows)
-    const maxCols = Math.max(...rows.map((r) => r.length));
-    const cells: CellInput[][] = rows.map((row) => {
-      const padded = [...row];
-      while (padded.length < maxCols) padded.push("");
-      return padded.map((raw) => ({ value: coerceValue(raw) }));
-    });
+    const [filePath, sheetIdStr, startCell = "A1"] = positional;
+    const sheetId = Number.parseInt(sheetIdStr, 10);
+    if (Number.isNaN(sheetId)) {
+      return {
+        stdout: "",
+        stderr: `Invalid sheetId: ${sheetIdStr}`,
+        exitCode: 1,
+      };
+    }
 
-    const rangeAddr = buildRangeAddress(upperStartCell, rows.length, maxCols);
-    const result = await setCellRange(sheetId, rangeAddr, cells, {
-      allowOverwrite: force,
-    });
+    const upperStartCell = startCell.toUpperCase();
+    if (!/^[A-Z]+\d+$/.test(upperStartCell)) {
+      return {
+        stdout: "",
+        stderr: `Invalid start cell: ${startCell}`,
+        exitCode: 1,
+      };
+    }
 
-    return {
-      stdout: `Imported ${rows.length} rows × ${maxCols} columns into sheet ${sheetId} at ${upperStartCell} (${rangeAddr}). ${result.cellsWritten} cells written.`,
-      stderr: "",
-      exitCode: 0,
-    };
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    return { stdout: "", stderr: msg, exitCode: 1 };
-  }
-});
+    try {
+      const resolvedPath = filePath.startsWith("/")
+        ? filePath
+        : `${ctx.cwd}/${filePath}`;
+      const content = await ctx.fs.readFile(resolvedPath);
+      const rows = parseCsv(content);
+
+      if (rows.length === 0) {
+        return { stdout: "", stderr: "CSV file is empty", exitCode: 1 };
+      }
+
+      // Normalize column count (pad shorter rows)
+      const maxCols = Math.max(...rows.map((r) => r.length));
+      const cells: CellInput[][] = rows.map((row) => {
+        const padded = [...row];
+        while (padded.length < maxCols) padded.push("");
+        return padded.map((raw) => ({ value: coerceValue(raw) }));
+      });
+
+      const rangeAddr = buildRangeAddress(upperStartCell, rows.length, maxCols);
+      const result = await setCellRange(sheetId, rangeAddr, cells, {
+        allowOverwrite: force,
+      });
+
+      return {
+        stdout: `Imported ${rows.length} rows × ${maxCols} columns into sheet ${sheetId} at ${upperStartCell} (${rangeAddr}). ${result.cellsWritten} cells written.`,
+        stderr: "",
+        exitCode: 0,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { stdout: "", stderr: msg, exitCode: 1 };
+    }
+  }),
+};
 
 function looksLikeRange(s: string): boolean {
   return /^[A-Z]+\d+(:[A-Z]+\d+)?$/i.test(s);
@@ -105,93 +112,99 @@ async function getUsedRangeAddress(sheetId: number): Promise<string | null> {
   });
 }
 
-const sheetToCsv: Command = defineCommand("sheet-to-csv", async (args, ctx) => {
-  if (args.length < 1) {
-    return {
-      stdout: "",
-      stderr:
-        "Usage: sheet-to-csv <sheetId> [range] [file]\n  sheetId - Source sheet ID (number)\n  range   - Cell range, e.g. A1:D100 (optional, defaults to used range)\n  file    - Output file path (optional, prints to stdout if omitted)\n",
-      exitCode: 1,
-    };
-  }
-
-  // Parse args: sheetId is always first, then optionally a range, then optionally a file
-  const sheetIdStr = args[0];
-  const sheetId = Number.parseInt(sheetIdStr, 10);
-  if (Number.isNaN(sheetId)) {
-    return {
-      stdout: "",
-      stderr: `Invalid sheetId: ${sheetIdStr}`,
-      exitCode: 1,
-    };
-  }
-
-  let rangeAddr: string | undefined;
-  let outFile: string | undefined;
-
-  if (args.length === 2) {
-    // Could be range or file
-    if (looksLikeRange(args[1])) {
-      rangeAddr = args[1];
-    } else {
-      outFile = args[1];
-    }
-  } else if (args.length >= 3) {
-    rangeAddr = args[1];
-    outFile = args[2];
-  }
-
-  try {
-    // Auto-detect used range if none specified
-    if (!rangeAddr) {
-      const usedAddr = await getUsedRangeAddress(sheetId);
-      if (!usedAddr) {
-        return {
-          stdout: "",
-          stderr: "Sheet is empty (no used range)",
-          exitCode: 1,
-        };
-      }
-      rangeAddr = usedAddr;
-    }
-
-    const result = await getRangeAsCsv(sheetId, rangeAddr, { maxRows: 50000 });
-
-    if (outFile) {
-      const resolvedPath = outFile.startsWith("/")
-        ? outFile
-        : `${ctx.cwd}/${outFile}`;
-      // Ensure parent directory exists
-      const dir = resolvedPath.substring(0, resolvedPath.lastIndexOf("/"));
-      if (dir && dir !== "/") {
-        try {
-          await ctx.fs.mkdir(dir, { recursive: true });
-        } catch {
-          // directory may already exist
-        }
-      }
-      await ctx.fs.writeFile(resolvedPath, result.csv);
-      const moreNote = result.hasMore
-        ? " (truncated, more rows available)"
-        : "";
+const sheetToCsv: DescribedCommand = {
+  promptSnippet:
+    "- sheet-to-csv <sheetId> [range] [file] — Export range to CSV. Defaults to full used range if no range given. Prints to stdout if no file given (pipeable).",
+  command: defineCommand("sheet-to-csv", async (args, ctx) => {
+    if (args.length < 1) {
       return {
-        stdout: `Exported ${result.rowCount} rows × ${result.columnCount} columns from "${result.sheetName}" to ${outFile}${moreNote}`,
-        stderr: "",
-        exitCode: 0,
+        stdout: "",
+        stderr:
+          "Usage: sheet-to-csv <sheetId> [range] [file]\n  sheetId - Source sheet ID (number)\n  range   - Cell range, e.g. A1:D100 (optional, defaults to used range)\n  file    - Output file path (optional, prints to stdout if omitted)\n",
+        exitCode: 1,
       };
     }
 
-    // No file → stdout (pipeable)
-    return {
-      stdout: result.csv,
-      stderr: "",
-      exitCode: 0,
-    };
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    return { stdout: "", stderr: msg, exitCode: 1 };
-  }
-});
+    // Parse args: sheetId is always first, then optionally a range, then optionally a file
+    const sheetIdStr = args[0];
+    const sheetId = Number.parseInt(sheetIdStr, 10);
+    if (Number.isNaN(sheetId)) {
+      return {
+        stdout: "",
+        stderr: `Invalid sheetId: ${sheetIdStr}`,
+        exitCode: 1,
+      };
+    }
+
+    let rangeAddr: string | undefined;
+    let outFile: string | undefined;
+
+    if (args.length === 2) {
+      // Could be range or file
+      if (looksLikeRange(args[1])) {
+        rangeAddr = args[1];
+      } else {
+        outFile = args[1];
+      }
+    } else if (args.length >= 3) {
+      rangeAddr = args[1];
+      outFile = args[2];
+    }
+
+    try {
+      // Auto-detect used range if none specified
+      if (!rangeAddr) {
+        const usedAddr = await getUsedRangeAddress(sheetId);
+        if (!usedAddr) {
+          return {
+            stdout: "",
+            stderr: "Sheet is empty (no used range)",
+            exitCode: 1,
+          };
+        }
+        rangeAddr = usedAddr;
+      }
+
+      const result = await getRangeAsCsv(sheetId, rangeAddr, {
+        maxRows: 50000,
+      });
+
+      if (outFile) {
+        const resolvedPath = outFile.startsWith("/")
+          ? outFile
+          : `${ctx.cwd}/${outFile}`;
+        // Ensure parent directory exists
+        const dir = resolvedPath.substring(0, resolvedPath.lastIndexOf("/"));
+        if (dir && dir !== "/") {
+          try {
+            await ctx.fs.mkdir(dir, { recursive: true });
+          } catch {
+            // directory may already exist
+          }
+        }
+        await ctx.fs.writeFile(resolvedPath, result.csv);
+        const moreNote = result.hasMore
+          ? " (truncated, more rows available)"
+          : "";
+        return {
+          stdout: `Exported ${result.rowCount} rows × ${result.columnCount} columns from "${result.sheetName}" to ${outFile}${moreNote}`,
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+
+      // No file → stdout (pipeable)
+      return {
+        stdout: result.csv,
+        stderr: "",
+        exitCode: 0,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { stdout: "", stderr: msg, exitCode: 1 };
+    }
+  }),
+};
 
 async function resolveVfsPath(
   ctx: { cwd: string; fs: { readFileBuffer(p: string): Promise<Uint8Array> } },
@@ -306,9 +319,10 @@ async function paintPixelsToSheet(
   });
 }
 
-const imageToSheet: Command = defineCommand(
-  "image-to-sheet",
-  async (args, ctx) => {
+const imageToSheet: DescribedCommand = {
+  promptSnippet:
+    "- image-to-sheet <file> <width> <height> <sheetId> [startCell] [--cell-size=N] — Render an image as pixel art in Excel. Downsamples to target size and paints cell backgrounds. Cell size in points (default: 6). Max 200×200. Example: image-to-sheet uploads/logo.png 64 64 1 A1 --cell-size=4",
+  command: defineCommand("image-to-sheet", async (args, ctx) => {
     const positional = args.filter((a) => !a.startsWith("--"));
     const cellSizeArg = args.find((a) => a.startsWith("--cell-size="));
     const cellSize = cellSizeArg
@@ -418,9 +432,17 @@ const imageToSheet: Command = defineCommand(
       const msg = error instanceof Error ? error.message : String(error);
       return { stdout: "", stderr: msg, exitCode: 1 };
     }
-  },
-);
+  }),
+};
 
-export function getCustomCommands(): CustomCommand[] {
-  return [csvToSheet, sheetToCsv, imageToSheet, ...getSharedCustomCommands()];
+export function getCustomCommands(): CustomCommandsResult {
+  const local: DescribedCommand[] = [csvToSheet, sheetToCsv, imageToSheet];
+  const shared = getSharedCustomCommands();
+  return {
+    commands: [...local.map((d) => d.command), ...shared.commands],
+    promptSnippets: [
+      ...local.map((d) => d.promptSnippet),
+      ...shared.promptSnippets,
+    ],
+  };
 }

--- a/packages/excel/src/lib/vfs/custom-commands.ts
+++ b/packages/excel/src/lib/vfs/custom-commands.ts
@@ -1,7 +1,7 @@
 import {
-  getSharedCustomCommands,
   type CustomCommandsResult,
   type DescribedCommand,
+  getSharedCustomCommands,
 } from "@office-agents/core";
 import { defineCommand } from "just-bash/browser";
 import type { CellInput } from "../excel/api";

--- a/packages/powerpoint/CHANGELOG.md
+++ b/packages/powerpoint/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Co-located command prompt snippets** — PowerPoint-specific VFS commands (`insert-image`, `search-icons`, `insert-icon`) now use `DescribedCommand` with co-located `promptSnippet`. System prompt assembles command docs dynamically from snippets instead of hard-coding them.
+
 ## [0.0.4] - 2026-03-19
 
 ### Changed

--- a/packages/powerpoint/src/lib/system-prompt.ts
+++ b/packages/powerpoint/src/lib/system-prompt.ts
@@ -1,6 +1,10 @@
 import { buildSkillsPromptSection, type SkillMeta } from "@office-agents/core";
 
-export function buildPowerPointSystemPrompt(skills: SkillMeta[]): string {
+export function buildPowerPointSystemPrompt(
+  skills: SkillMeta[],
+  commandSnippets: string[] = [],
+): string {
+  const customCommandsList = commandSnippets.map((s) => `  ${s}`).join("\n");
   return `You are an AI assistant integrated into Microsoft PowerPoint with direct Office.js access.
 
 ## Office.js API Reference
@@ -14,16 +18,7 @@ FILES & SHELL:
 - read: Read uploaded files (images, CSV, text). Images are returned for visual analysis.
 - bash: Execute bash commands in a sandboxed virtual filesystem. User uploads are in /home/user/uploads/.
   Custom commands available in bash:
-  - pdf-to-text <file> <outfile> — Extract text from a PDF
-  - pdf-to-images <file> <outdir> [--scale=N] [--pages=1,3,5-8] — Render PDF pages as PNG images
-  - docx-to-text <file> <outfile> — Extract text from a DOCX file
-  - xlsx-to-csv <file> <outfile> [sheet] — Convert XLSX/XLS/ODS to CSV
-  - web-search <query> [--max=N] [--json] — Search the web
-  - web-fetch <url> <outfile> — Fetch a URL (HTML→Markdown, binary→raw file)
-  - image-search <query> [--num=N] [--page=N] [--gl=COUNTRY] [--hl=LANG] [--json] — Search for images. Returns image URLs, dimensions, source, and page link.
-  - insert-image <file> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--name=NAME] — Insert a VFS image onto a slide (1-based slide number, default box 360×270 pt at origin, preserves aspect ratio)
-  - search-icons <query> [--limit=N] [--prefix=ICON_SET] [--prefixes=SET1,SET2] — Search 200k+ vector icons from Iconify (Material, Fluent, Phosphor, Heroicons, Tabler, FontAwesome, etc.)
-  - insert-icon <icon_id> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--color=#HEX] [--name=NAME] — Insert a vector icon onto a slide as SVG with PNG fallback (default box 72×72 pt, preserves aspect ratio)
+${customCommandsList}
 
 POWERPOINT READ:
 - screenshot_slide: Take a screenshot of a slide for visual verification

--- a/packages/powerpoint/src/lib/vfs/custom-commands.ts
+++ b/packages/powerpoint/src/lib/vfs/custom-commands.ts
@@ -1,5 +1,8 @@
-import { getSharedCustomCommands } from "@office-agents/core";
-import type { CustomCommand } from "just-bash/browser";
+import {
+  getSharedCustomCommands,
+  type CustomCommandsResult,
+  type DescribedCommand,
+} from "@office-agents/core";
 import { defineCommand } from "just-bash/browser";
 import { safeRun, withSlideZip } from "../pptx/slide-zip";
 
@@ -405,367 +408,392 @@ async function insertImageIntoSlide(params: InsertImageParams): Promise<void> {
   });
 }
 
-const insertImageCmd: CustomCommand = {
-  name: "insert-image",
-  load: async () =>
-    defineCommand("insert-image", async (args, ctx) => {
-      const flags: Record<string, string> = {};
-      const positional: string[] = [];
-      for (const arg of args) {
-        const match = arg.match(/^--(\w+)=(.+)$/);
-        if (match) {
-          flags[match[1]] = match[2];
-        } else {
-          positional.push(arg);
+const insertImageCmd: DescribedCommand = {
+  promptSnippet:
+    "- insert-image <file> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--name=NAME] — Insert a VFS image onto a slide (1-based slide number, default box 360×270 pt at origin, preserves aspect ratio)",
+  command: {
+    name: "insert-image",
+    load: async () =>
+      defineCommand("insert-image", async (args, ctx) => {
+        const flags: Record<string, string> = {};
+        const positional: string[] = [];
+        for (const arg of args) {
+          const match = arg.match(/^--(\w+)=(.+)$/);
+          if (match) {
+            flags[match[1]] = match[2];
+          } else {
+            positional.push(arg);
+          }
         }
-      }
 
-      if (positional.length < 2) {
-        return {
-          stdout: "",
-          stderr:
-            "Usage: insert-image <file> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--name=SHAPE_NAME]\n" +
-            "  file    - Path to image file in VFS (PNG, JPEG, GIF, BMP, SVG, WEBP)\n" +
-            "  slide   - 1-based slide number\n" +
-            "  --x     - Horizontal position from left edge (default: 0)\n" +
-            "  --y     - Vertical position from top edge (default: 0)\n" +
-            "  --width - Image width (default box width: 360pt)\n" +
-            "  --height- Image height (default box height: 270pt)\n" +
-            "  --unit  - Unit: pt (default), in, cm, emu\n" +
-            "  --name  - Shape name (default: image filename)\n",
-          exitCode: 1,
-        };
-      }
+        if (positional.length < 2) {
+          return {
+            stdout: "",
+            stderr:
+              "Usage: insert-image <file> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--name=SHAPE_NAME]\n" +
+              "  file    - Path to image file in VFS (PNG, JPEG, GIF, BMP, SVG, WEBP)\n" +
+              "  slide   - 1-based slide number\n" +
+              "  --x     - Horizontal position from left edge (default: 0)\n" +
+              "  --y     - Vertical position from top edge (default: 0)\n" +
+              "  --width - Image width (default box width: 360pt)\n" +
+              "  --height- Image height (default box height: 270pt)\n" +
+              "  --unit  - Unit: pt (default), in, cm, emu\n" +
+              "  --name  - Shape name (default: image filename)\n",
+            exitCode: 1,
+          };
+        }
 
-      const [filePath, slideArg] = positional;
-      const slideNum = Number.parseInt(slideArg, 10);
-      if (Number.isNaN(slideNum) || slideNum < 1) {
-        return {
-          stdout: "",
-          stderr: "Slide must be a positive number (1-based)",
-          exitCode: 1,
-        };
-      }
-      const slideIndex = slideNum - 1;
+        const [filePath, slideArg] = positional;
+        const slideNum = Number.parseInt(slideArg, 10);
+        if (Number.isNaN(slideNum) || slideNum < 1) {
+          return {
+            stdout: "",
+            stderr: "Slide must be a positive number (1-based)",
+            exitCode: 1,
+          };
+        }
+        const slideIndex = slideNum - 1;
 
-      const unit = flags.unit || "pt";
-      if (!["in", "cm", "pt", "emu"].includes(unit)) {
-        return {
-          stdout: "",
-          stderr: "Unit must be one of: in, cm, pt, emu",
-          exitCode: 1,
-        };
-      }
+        const unit = flags.unit || "pt";
+        if (!["in", "cm", "pt", "emu"].includes(unit)) {
+          return {
+            stdout: "",
+            stderr: "Unit must be one of: in, cm, pt, emu",
+            exitCode: 1,
+          };
+        }
 
-      const x = flags.x ? Number.parseFloat(flags.x) : 0;
-      const y = flags.y ? Number.parseFloat(flags.y) : 0;
-      const width = flags.width ? Number.parseFloat(flags.width) : undefined;
-      const height = flags.height ? Number.parseFloat(flags.height) : undefined;
-      const widthProvided = width !== undefined;
-      const heightProvided = height !== undefined;
+        const x = flags.x ? Number.parseFloat(flags.x) : 0;
+        const y = flags.y ? Number.parseFloat(flags.y) : 0;
+        const width = flags.width ? Number.parseFloat(flags.width) : undefined;
+        const height = flags.height
+          ? Number.parseFloat(flags.height)
+          : undefined;
+        const widthProvided = width !== undefined;
+        const heightProvided = height !== undefined;
 
-      if (
-        [x, y, width, height].some((v) => v !== undefined && Number.isNaN(v))
-      ) {
-        return {
-          stdout: "",
-          stderr: "x, y, width, height must be valid numbers",
-          exitCode: 1,
-        };
-      }
+        if (
+          [x, y, width, height].some((v) => v !== undefined && Number.isNaN(v))
+        ) {
+          return {
+            stdout: "",
+            stderr: "x, y, width, height must be valid numbers",
+            exitCode: 1,
+          };
+        }
 
-      try {
-        const data = await resolveVfsPath(ctx, filePath);
-        const { mime, ext } = detectMimeType(filePath, data);
-        const fileName = filePath.split("/").pop() || "image";
-        const shapeName = flags.name || fileName;
-        const intrinsic = await getImageDimensions(data, ext);
-        const resolvedSize = resolveImageSize({
-          intrinsic,
-          requestedWidth: width,
-          requestedHeight: height,
-          widthProvided,
-          heightProvided,
-          defaultWidth: DEFAULT_IMAGE_BOX_PT.width,
-          defaultHeight: DEFAULT_IMAGE_BOX_PT.height,
-        });
+        try {
+          const data = await resolveVfsPath(ctx, filePath);
+          const { mime, ext } = detectMimeType(filePath, data);
+          const fileName = filePath.split("/").pop() || "image";
+          const shapeName = flags.name || fileName;
+          const intrinsic = await getImageDimensions(data, ext);
+          const resolvedSize = resolveImageSize({
+            intrinsic,
+            requestedWidth: width,
+            requestedHeight: height,
+            widthProvided,
+            heightProvided,
+            defaultWidth: DEFAULT_IMAGE_BOX_PT.width,
+            defaultHeight: DEFAULT_IMAGE_BOX_PT.height,
+          });
 
-        await insertImageIntoSlide({
-          slideIndex,
-          data,
-          mime,
-          ext,
-          shapeName,
-          offX: parseUnit(x, unit),
-          offY: parseUnit(y, unit),
-          cx: parseUnit(resolvedSize.width, unit),
-          cy: parseUnit(resolvedSize.height, unit),
-        });
+          await insertImageIntoSlide({
+            slideIndex,
+            data,
+            mime,
+            ext,
+            shapeName,
+            offX: parseUnit(x, unit),
+            offY: parseUnit(y, unit),
+            cx: parseUnit(resolvedSize.width, unit),
+            cy: parseUnit(resolvedSize.height, unit),
+          });
 
-        return {
-          stdout: `Inserted ${fileName} on slide ${slideNum} at (${x}, ${y}) size ${resolvedSize.width}×${resolvedSize.height} ${unit}`,
-          stderr: "",
-          exitCode: 0,
-        };
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { stdout: "", stderr: msg, exitCode: 1 };
-      }
-    }),
+          return {
+            stdout: `Inserted ${fileName} on slide ${slideNum} at (${x}, ${y}) size ${resolvedSize.width}×${resolvedSize.height} ${unit}`,
+            stderr: "",
+            exitCode: 0,
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return { stdout: "", stderr: msg, exitCode: 1 };
+        }
+      }),
+  },
 };
 
 const ICONIFY_API = "https://api.iconify.design";
 
-const searchIconsCmd: CustomCommand = {
-  name: "search-icons",
-  load: async () =>
-    defineCommand("search-icons", async (args) => {
-      const flags: Record<string, string> = {};
-      const positional: string[] = [];
-      for (const arg of args) {
-        const match = arg.match(/^--(\w+)=(.+)$/);
-        if (match) {
-          flags[match[1]] = match[2];
-        } else {
-          positional.push(arg);
-        }
-      }
-
-      const query = positional.join(" ");
-      if (!query) {
-        return {
-          stdout: "",
-          stderr:
-            "Usage: search-icons <query> [--limit=N] [--prefix=ICON_SET] [--prefixes=SET1,SET2]\n" +
-            "  query      - Search term (e.g. 'warning', 'chart', 'home')\n" +
-            "  --limit    - Max results (default: 32, min: 32, max: 999)\n" +
-            "  --prefix   - Limit to one icon set (e.g. 'mdi', 'fluent')\n" +
-            "  --prefixes - Comma-separated icon set prefixes (e.g. 'mdi,fluent,tabler')\n",
-          exitCode: 1,
-        };
-      }
-
-      try {
-        const limit = flags.limit
-          ? Math.max(32, Math.min(999, Number.parseInt(flags.limit, 10)))
-          : 32;
-        const params = new URLSearchParams({
-          query,
-          limit: String(limit),
-        });
-        if (flags.prefix) params.set("prefix", flags.prefix);
-        if (flags.prefixes) params.set("prefixes", flags.prefixes);
-
-        const res = await fetch(`${ICONIFY_API}/search?${params}`);
-        if (!res.ok) {
-          throw new Error(`Iconify API error: ${res.status} ${res.statusText}`);
+const searchIconsCmd: DescribedCommand = {
+  promptSnippet:
+    "- search-icons <query> [--limit=N] [--prefix=ICON_SET] [--prefixes=SET1,SET2] — Search 200k+ vector icons from Iconify (Material, Fluent, Phosphor, Heroicons, Tabler, FontAwesome, etc.)",
+  command: {
+    name: "search-icons",
+    load: async () =>
+      defineCommand("search-icons", async (args) => {
+        const flags: Record<string, string> = {};
+        const positional: string[] = [];
+        for (const arg of args) {
+          const match = arg.match(/^--(\w+)=(.+)$/);
+          if (match) {
+            flags[match[1]] = match[2];
+          } else {
+            positional.push(arg);
+          }
         }
 
-        const data: {
-          icons: string[];
-          total: number;
-          limit: number;
-          start: number;
-          collections: Record<
-            string,
-            {
-              name: string;
-              author?: { name: string };
-              license?: { title: string };
-              palette?: boolean;
-            }
-          >;
-        } = await res.json();
-
-        if (data.icons.length === 0) {
+        const query = positional.join(" ");
+        if (!query) {
           return {
-            stdout: "No icons found for that query.",
-            stderr: "",
-            exitCode: 0,
+            stdout: "",
+            stderr:
+              "Usage: search-icons <query> [--limit=N] [--prefix=ICON_SET] [--prefixes=SET1,SET2]\n" +
+              "  query      - Search term (e.g. 'warning', 'chart', 'home')\n" +
+              "  --limit    - Max results (default: 32, min: 32, max: 999)\n" +
+              "  --prefix   - Limit to one icon set (e.g. 'mdi', 'fluent')\n" +
+              "  --prefixes - Comma-separated icon set prefixes (e.g. 'mdi,fluent,tabler')\n",
+            exitCode: 1,
           };
         }
 
-        const lines: string[] = [];
-        lines.push(
-          `Found ${data.total} icon(s) (showing ${data.icons.length}):\n`,
-        );
+        try {
+          const limit = flags.limit
+            ? Math.max(32, Math.min(999, Number.parseInt(flags.limit, 10)))
+            : 32;
+          const params = new URLSearchParams({
+            query,
+            limit: String(limit),
+          });
+          if (flags.prefix) params.set("prefix", flags.prefix);
+          if (flags.prefixes) params.set("prefixes", flags.prefixes);
 
-        for (const iconId of data.icons) {
-          const [prefix] = iconId.split(":");
-          const col = data.collections[prefix];
-          const setInfo = col ? ` [${col.name}]` : "";
-          lines.push(`  ${iconId}${setInfo}`);
-        }
-
-        if (Object.keys(data.collections).length > 0) {
-          lines.push("\nIcon sets in results:");
-          for (const [prefix, info] of Object.entries(data.collections)) {
-            const author = info.author ? ` by ${info.author.name}` : "";
-            const license = info.license ? ` (${info.license.title})` : "";
-            const palette = info.palette ? ", multi-color" : ", mono";
-            lines.push(
-              `  ${prefix}: ${info.name}${author}${license}${palette}`,
-            );
-          }
-        }
-
-        lines.push(
-          "\nUse insert-icon to place an icon on a slide:",
-          "  insert-icon <icon_id> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--color=#HEX]",
-        );
-
-        return { stdout: lines.join("\n"), stderr: "", exitCode: 0 };
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { stdout: "", stderr: msg, exitCode: 1 };
-      }
-    }),
-};
-
-const insertIconCmd: CustomCommand = {
-  name: "insert-icon",
-  load: async () =>
-    defineCommand("insert-icon", async (args) => {
-      const flags: Record<string, string> = {};
-      const positional: string[] = [];
-      for (const arg of args) {
-        const match = arg.match(/^--(\w+)=(.+)$/);
-        if (match) {
-          flags[match[1]] = match[2];
-        } else {
-          positional.push(arg);
-        }
-      }
-
-      if (positional.length < 2) {
-        return {
-          stdout: "",
-          stderr:
-            "Usage: insert-icon <icon_id> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--color=#HEX] [--name=SHAPE_NAME]\n" +
-            "  icon_id  - Icon ID from search-icons (e.g. 'mdi:alert', 'fluent:warning-24-filled')\n" +
-            "  slide    - 1-based slide number\n" +
-            "  --x      - Horizontal position from left edge (default: 0)\n" +
-            "  --y      - Vertical position from top edge (default: 0)\n" +
-            "  --width  - Icon width (default box width: 72pt)\n" +
-            "  --height - Icon height (default box height: 72pt)\n" +
-            "  --unit   - Unit: pt (default), in, cm, emu\n" +
-            "  --color  - Icon color as hex (e.g. '#FF5733'). Only works on mono icons.\n" +
-            "  --name   - Shape name (default: icon ID)\n",
-          exitCode: 1,
-        };
-      }
-
-      const [iconId, slideArg] = positional;
-      const slideNum = Number.parseInt(slideArg, 10);
-      if (Number.isNaN(slideNum) || slideNum < 1) {
-        return {
-          stdout: "",
-          stderr: "Slide must be a positive number (1-based)",
-          exitCode: 1,
-        };
-      }
-
-      const parts = iconId.split(":");
-      if (parts.length !== 2) {
-        return {
-          stdout: "",
-          stderr:
-            'Icon ID must be in "prefix:name" format (e.g. "mdi:alert"). Use search-icons to find icons.',
-          exitCode: 1,
-        };
-      }
-
-      const unit = flags.unit || "pt";
-      if (!["in", "cm", "pt", "emu"].includes(unit)) {
-        return {
-          stdout: "",
-          stderr: "Unit must be one of: in, cm, pt, emu",
-          exitCode: 1,
-        };
-      }
-
-      const x = flags.x ? Number.parseFloat(flags.x) : 0;
-      const y = flags.y ? Number.parseFloat(flags.y) : 0;
-      const width = flags.width ? Number.parseFloat(flags.width) : undefined;
-      const height = flags.height ? Number.parseFloat(flags.height) : undefined;
-      const widthProvided = width !== undefined;
-      const heightProvided = height !== undefined;
-
-      if (
-        [x, y, width, height].some((v) => v !== undefined && Number.isNaN(v))
-      ) {
-        return {
-          stdout: "",
-          stderr: "x, y, width, height must be valid numbers",
-          exitCode: 1,
-        };
-      }
-
-      try {
-        const [prefix, name] = parts;
-        const svgUrl = new URL(`${ICONIFY_API}/${prefix}/${name}.svg`);
-        if (flags.color) {
-          svgUrl.searchParams.set("color", flags.color);
-        }
-
-        const res = await fetch(svgUrl.toString());
-        if (!res.ok) {
-          if (res.status === 404) {
+          const res = await fetch(`${ICONIFY_API}/search?${params}`);
+          if (!res.ok) {
             throw new Error(
-              `Icon "${iconId}" not found. Use search-icons to find valid icon IDs.`,
+              `Iconify API error: ${res.status} ${res.statusText}`,
             );
           }
-          throw new Error(
-            `Failed to fetch icon: ${res.status} ${res.statusText}`,
+
+          const data: {
+            icons: string[];
+            total: number;
+            limit: number;
+            start: number;
+            collections: Record<
+              string,
+              {
+                name: string;
+                author?: { name: string };
+                license?: { title: string };
+                palette?: boolean;
+              }
+            >;
+          } = await res.json();
+
+          if (data.icons.length === 0) {
+            return {
+              stdout: "No icons found for that query.",
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+
+          const lines: string[] = [];
+          lines.push(
+            `Found ${data.total} icon(s) (showing ${data.icons.length}):\n`,
           );
+
+          for (const iconId of data.icons) {
+            const [prefix] = iconId.split(":");
+            const col = data.collections[prefix];
+            const setInfo = col ? ` [${col.name}]` : "";
+            lines.push(`  ${iconId}${setInfo}`);
+          }
+
+          if (Object.keys(data.collections).length > 0) {
+            lines.push("\nIcon sets in results:");
+            for (const [prefix, info] of Object.entries(data.collections)) {
+              const author = info.author ? ` by ${info.author.name}` : "";
+              const license = info.license ? ` (${info.license.title})` : "";
+              const palette = info.palette ? ", multi-color" : ", mono";
+              lines.push(
+                `  ${prefix}: ${info.name}${author}${license}${palette}`,
+              );
+            }
+          }
+
+          lines.push(
+            "\nUse insert-icon to place an icon on a slide:",
+            "  insert-icon <icon_id> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--color=#HEX]",
+          );
+
+          return { stdout: lines.join("\n"), stderr: "", exitCode: 0 };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return { stdout: "", stderr: msg, exitCode: 1 };
         }
-
-        const svgText = await res.text();
-        const svgData = new TextEncoder().encode(svgText);
-        const shapeName = flags.name || iconId;
-        const mediaCount = Date.now();
-        const intrinsic = await getImageDimensions(svgData, "svg");
-        const resolvedSize = resolveImageSize({
-          intrinsic,
-          requestedWidth: width,
-          requestedHeight: height,
-          widthProvided,
-          heightProvided,
-          defaultWidth: DEFAULT_ICON_BOX_PT.width,
-          defaultHeight: DEFAULT_ICON_BOX_PT.height,
-        });
-
-        await insertImageIntoSlide({
-          slideIndex: slideNum - 1,
-          data: svgData,
-          mime: "image/svg+xml",
-          ext: "svg",
-          shapeName,
-          offX: parseUnit(x, unit),
-          offY: parseUnit(y, unit),
-          cx: parseUnit(resolvedSize.width, unit),
-          cy: parseUnit(resolvedSize.height, unit),
-          mediaPrefix: `icon_${mediaCount}`,
-        });
-
-        const colorInfo = flags.color ? ` (color: ${flags.color})` : "";
-        return {
-          stdout: `Inserted icon "${iconId}" on slide ${slideNum} at (${x}, ${y}) size ${resolvedSize.width}×${resolvedSize.height} ${unit}${colorInfo}`,
-          stderr: "",
-          exitCode: 0,
-        };
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { stdout: "", stderr: msg, exitCode: 1 };
-      }
-    }),
+      }),
+  },
 };
 
-export function getCustomCommands(): CustomCommand[] {
-  return [
-    ...getSharedCustomCommands({ includeImageSearch: true }),
+const insertIconCmd: DescribedCommand = {
+  promptSnippet:
+    "- insert-icon <icon_id> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--color=#HEX] [--name=NAME] — Insert a vector icon onto a slide as SVG with PNG fallback (default box 72×72 pt, preserves aspect ratio)",
+  command: {
+    name: "insert-icon",
+    load: async () =>
+      defineCommand("insert-icon", async (args) => {
+        const flags: Record<string, string> = {};
+        const positional: string[] = [];
+        for (const arg of args) {
+          const match = arg.match(/^--(\w+)=(.+)$/);
+          if (match) {
+            flags[match[1]] = match[2];
+          } else {
+            positional.push(arg);
+          }
+        }
+
+        if (positional.length < 2) {
+          return {
+            stdout: "",
+            stderr:
+              "Usage: insert-icon <icon_id> <slide> [--x=N] [--y=N] [--width=N] [--height=N] [--unit=pt|in|cm|emu] [--color=#HEX] [--name=SHAPE_NAME]\n" +
+              "  icon_id  - Icon ID from search-icons (e.g. 'mdi:alert', 'fluent:warning-24-filled')\n" +
+              "  slide    - 1-based slide number\n" +
+              "  --x      - Horizontal position from left edge (default: 0)\n" +
+              "  --y      - Vertical position from top edge (default: 0)\n" +
+              "  --width  - Icon width (default box width: 72pt)\n" +
+              "  --height - Icon height (default box height: 72pt)\n" +
+              "  --unit   - Unit: pt (default), in, cm, emu\n" +
+              "  --color  - Icon color as hex (e.g. '#FF5733'). Only works on mono icons.\n" +
+              "  --name   - Shape name (default: icon ID)\n",
+            exitCode: 1,
+          };
+        }
+
+        const [iconId, slideArg] = positional;
+        const slideNum = Number.parseInt(slideArg, 10);
+        if (Number.isNaN(slideNum) || slideNum < 1) {
+          return {
+            stdout: "",
+            stderr: "Slide must be a positive number (1-based)",
+            exitCode: 1,
+          };
+        }
+
+        const parts = iconId.split(":");
+        if (parts.length !== 2) {
+          return {
+            stdout: "",
+            stderr:
+              'Icon ID must be in "prefix:name" format (e.g. "mdi:alert"). Use search-icons to find icons.',
+            exitCode: 1,
+          };
+        }
+
+        const unit = flags.unit || "pt";
+        if (!["in", "cm", "pt", "emu"].includes(unit)) {
+          return {
+            stdout: "",
+            stderr: "Unit must be one of: in, cm, pt, emu",
+            exitCode: 1,
+          };
+        }
+
+        const x = flags.x ? Number.parseFloat(flags.x) : 0;
+        const y = flags.y ? Number.parseFloat(flags.y) : 0;
+        const width = flags.width ? Number.parseFloat(flags.width) : undefined;
+        const height = flags.height
+          ? Number.parseFloat(flags.height)
+          : undefined;
+        const widthProvided = width !== undefined;
+        const heightProvided = height !== undefined;
+
+        if (
+          [x, y, width, height].some((v) => v !== undefined && Number.isNaN(v))
+        ) {
+          return {
+            stdout: "",
+            stderr: "x, y, width, height must be valid numbers",
+            exitCode: 1,
+          };
+        }
+
+        try {
+          const [prefix, name] = parts;
+          const svgUrl = new URL(`${ICONIFY_API}/${prefix}/${name}.svg`);
+          if (flags.color) {
+            svgUrl.searchParams.set("color", flags.color);
+          }
+
+          const res = await fetch(svgUrl.toString());
+          if (!res.ok) {
+            if (res.status === 404) {
+              throw new Error(
+                `Icon "${iconId}" not found. Use search-icons to find valid icon IDs.`,
+              );
+            }
+            throw new Error(
+              `Failed to fetch icon: ${res.status} ${res.statusText}`,
+            );
+          }
+
+          const svgText = await res.text();
+          const svgData = new TextEncoder().encode(svgText);
+          const shapeName = flags.name || iconId;
+          const mediaCount = Date.now();
+          const intrinsic = await getImageDimensions(svgData, "svg");
+          const resolvedSize = resolveImageSize({
+            intrinsic,
+            requestedWidth: width,
+            requestedHeight: height,
+            widthProvided,
+            heightProvided,
+            defaultWidth: DEFAULT_ICON_BOX_PT.width,
+            defaultHeight: DEFAULT_ICON_BOX_PT.height,
+          });
+
+          await insertImageIntoSlide({
+            slideIndex: slideNum - 1,
+            data: svgData,
+            mime: "image/svg+xml",
+            ext: "svg",
+            shapeName,
+            offX: parseUnit(x, unit),
+            offY: parseUnit(y, unit),
+            cx: parseUnit(resolvedSize.width, unit),
+            cy: parseUnit(resolvedSize.height, unit),
+            mediaPrefix: `icon_${mediaCount}`,
+          });
+
+          const colorInfo = flags.color ? ` (color: ${flags.color})` : "";
+          return {
+            stdout: `Inserted icon "${iconId}" on slide ${slideNum} at (${x}, ${y}) size ${resolvedSize.width}×${resolvedSize.height} ${unit}${colorInfo}`,
+            stderr: "",
+            exitCode: 0,
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return { stdout: "", stderr: msg, exitCode: 1 };
+        }
+      }),
+  },
+};
+
+export function getCustomCommands(): CustomCommandsResult {
+  const local: DescribedCommand[] = [
     insertImageCmd,
     searchIconsCmd,
     insertIconCmd,
   ];
+  const shared = getSharedCustomCommands({ includeImageSearch: true });
+  return {
+    commands: [...shared.commands, ...local.map((d) => d.command)],
+    promptSnippets: [
+      ...shared.promptSnippets,
+      ...local.map((d) => d.promptSnippet),
+    ],
+  };
 }

--- a/packages/powerpoint/src/lib/vfs/custom-commands.ts
+++ b/packages/powerpoint/src/lib/vfs/custom-commands.ts
@@ -1,7 +1,7 @@
 import {
-  getSharedCustomCommands,
   type CustomCommandsResult,
   type DescribedCommand,
+  getSharedCustomCommands,
 } from "@office-agents/core";
 import { defineCommand } from "just-bash/browser";
 import { safeRun, withSlideZip } from "../pptx/slide-zip";

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Co-located command prompt snippets** — Custom VFS commands now carry their own `promptSnippet` via the new `DescribedCommand` type, instead of duplicating descriptions in system prompts. `getSharedCustomCommands()` returns `CustomCommandsResult { commands, promptSnippets }`, and `RuntimeAdapter.buildSystemPrompt` receives the filtered snippets as a second argument. Commands with `isAvailable` returning `false` are excluded from prompt snippets but still registered.
+
 ## [0.0.6] - 2026-03-19
 
 ### Fixes

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -103,6 +103,8 @@ export {
   getBash,
   getFileType,
   getSharedCustomCommands,
+  type CustomCommandsResult,
+  type DescribedCommand,
   getVfs,
   listUploads,
   readFile,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -98,13 +98,13 @@ export {
 } from "./truncate";
 // VFS
 export {
+  type CustomCommandsResult,
+  type DescribedCommand,
   deleteFile,
   fileExists,
   getBash,
   getFileType,
   getSharedCustomCommands,
-  type CustomCommandsResult,
-  type DescribedCommand,
   getVfs,
   listUploads,
   readFile,

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -13,7 +13,6 @@ import {
   type Model,
   streamSimple,
 } from "@mariozechner/pi-ai";
-import type { CustomCommand } from "just-bash/browser";
 import {
   agentMessagesToChatMessages,
   type ChatMessage,
@@ -54,6 +53,7 @@ import {
   saveVfsFiles,
 } from "./storage";
 import {
+  type CustomCommandsResult,
   deleteFile,
   listUploads,
   resetVfs,
@@ -66,7 +66,7 @@ import {
 
 export interface RuntimeAdapter {
   tools: AgentTool[];
-  buildSystemPrompt: (skills: SkillMeta[]) => string;
+  buildSystemPrompt: (skills: SkillMeta[], commandSnippets: string[]) => string;
   getDocumentId: () => Promise<string>;
   getDocumentMetadata?: () => Promise<{
     metadata: object;
@@ -75,7 +75,7 @@ export interface RuntimeAdapter {
   onToolResult?: (toolCallId: string, result: string, isError: boolean) => void;
   metadataTag?: string;
   staticFiles?: Record<string, string>;
-  customCommands?: () => CustomCommand[];
+  customCommands?: () => CustomCommandsResult;
 }
 
 export interface UploadedFile {
@@ -117,6 +117,7 @@ export class AgentRuntime {
   private sessionLoaded = false;
   private followMode = true;
   private skills: SkillMeta[] = [];
+  private commandSnippets: string[] = [];
   private adapter: RuntimeAdapter;
   private listeners: Set<StateListener> = new Set();
   private state: RuntimeState;
@@ -441,7 +442,14 @@ export class AgentRuntime {
       this.agent.abort();
     }
 
-    const systemPrompt = this.adapter.buildSystemPrompt(this.skills);
+    if (this.adapter.customCommands) {
+      this.commandSnippets = this.adapter.customCommands().promptSnippets;
+    }
+
+    const systemPrompt = this.adapter.buildSystemPrompt(
+      this.skills,
+      this.commandSnippets,
+    );
 
     const agent = new Agent({
       initialState: {
@@ -695,7 +703,10 @@ export class AgentRuntime {
       setStaticFiles(this.adapter.staticFiles);
     }
     if (this.adapter.customCommands) {
-      setCustomCommands(this.adapter.customCommands);
+      const customCmds = this.adapter.customCommands;
+      const result = customCmds();
+      this.commandSnippets = result.promptSnippets;
+      setCustomCommands(() => result.commands);
     }
 
     try {

--- a/packages/sdk/src/vfs/custom-commands.ts
+++ b/packages/sdk/src/vfs/custom-commands.ts
@@ -1,4 +1,4 @@
-import type { Command, CustomCommand } from "just-bash/browser";
+import type { CustomCommand } from "just-bash/browser";
 import { defineCommand } from "just-bash/browser";
 import { loadPdfDocument } from "../pdf";
 import { loadSavedConfig } from "../provider-config";

--- a/packages/sdk/src/vfs/custom-commands.ts
+++ b/packages/sdk/src/vfs/custom-commands.ts
@@ -18,6 +18,12 @@ interface CommandContext {
   fs: CommandFs;
 }
 
+export interface DescribedCommand {
+  command: CustomCommand;
+  promptSnippet: string;
+  isAvailable?: () => boolean;
+}
+
 export interface SharedCustomCommandOptions {
   includeImageSearch?: boolean;
 }
@@ -56,483 +62,531 @@ function getProxyUrl(): string | undefined {
   return config?.useProxy && config?.proxyUrl ? config.proxyUrl : undefined;
 }
 
-const pdfToText: CustomCommand = {
-  name: "pdf-to-text",
-  load: async () =>
-    defineCommand("pdf-to-text", async (args, ctx) => {
-      if (args.length < 2) {
-        return {
-          stdout: "",
-          stderr:
-            "Usage: pdf-to-text <file> <outfile>\n  file    - Path to PDF file in VFS\n  outfile - Output text file\n",
-          exitCode: 1,
-        };
-      }
-
-      const [filePath, outFile] = args;
-
-      try {
-        const data = await resolveVfsPath(ctx, filePath);
-        const doc = await loadPdfDocument(data);
-        const pages: string[] = [];
-
-        for (let i = 1; i <= doc.numPages; i++) {
-          const page = await doc.getPage(i);
-          const content = await page.getTextContent();
-          const text = content.items
-            .filter((item) => "str" in item)
-            .map((item) => (item as { str: string }).str)
-            .join(" ");
-          if (text.trim()) pages.push(text);
-        }
-
-        const fullText = pages.join("\n\n");
-        await writeVfsOutput(ctx, outFile, fullText);
-
-        return {
-          stdout: `Extracted text from ${doc.numPages} page(s) to ${outFile} (${fullText.length} chars)`,
-          stderr: "",
-          exitCode: 0,
-        };
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { stdout: "", stderr: msg, exitCode: 1 };
-      }
-    }),
-};
-
-const pdfToImages: CustomCommand = {
-  name: "pdf-to-images",
-  load: async () =>
-    defineCommand("pdf-to-images", async (args, ctx) => {
-      const positional = args.filter((arg) => !arg.startsWith("--"));
-      const scaleArg = args.find((arg) => arg.startsWith("--scale="));
-      const pagesArg = args.find((arg) => arg.startsWith("--pages="));
-
-      if (positional.length < 2) {
-        return {
-          stdout: "",
-          stderr:
-            "Usage: pdf-to-images <file> <outdir> [--scale=N] [--pages=1,3,5-8]\n  file    - Path to PDF file in VFS\n  outdir  - Output directory for PNG images\n  --scale - Render scale factor (default: 2)\n  --pages - Page selection (e.g. 1,3,5-8). Default: all\n",
-          exitCode: 1,
-        };
-      }
-
-      const [filePath, outDir] = positional;
-      const scale = scaleArg ? Number.parseFloat(scaleArg.split("=")[1]) : 2;
-
-      if (Number.isNaN(scale) || scale <= 0 || scale > 5) {
-        return {
-          stdout: "",
-          stderr: "Scale must be between 0 and 5",
-          exitCode: 1,
-        };
-      }
-
-      try {
-        const data = await resolveVfsPath(ctx, filePath);
-        const doc = await loadPdfDocument(data);
-
-        const selectedPages = pagesArg
-          ? parsePageRanges(pagesArg.split("=")[1], doc.numPages)
-          : new Set(Array.from({ length: doc.numPages }, (_, i) => i + 1));
-
-        if (selectedPages.size === 0) {
+const pdfToText: DescribedCommand = {
+  promptSnippet:
+    "- pdf-to-text <file> <outfile> — Extract text from PDF to file. Use head/grep/tail to read selectively.",
+  command: {
+    name: "pdf-to-text",
+    load: async () =>
+      defineCommand("pdf-to-text", async (args, ctx) => {
+        if (args.length < 2) {
           return {
             stdout: "",
-            stderr: "No valid pages in selection",
+            stderr:
+              "Usage: pdf-to-text <file> <outfile>\n  file    - Path to PDF file in VFS\n  outfile - Output text file\n",
             exitCode: 1,
           };
         }
 
-        const resolvedDir = resolvePath(ctx.cwd, outDir);
+        const [filePath, outFile] = args;
+
         try {
-          await ctx.fs.mkdir(resolvedDir, { recursive: true });
-        } catch {
-          // directory may already exist
-        }
+          const data = await resolveVfsPath(ctx, filePath);
+          const doc = await loadPdfDocument(data);
+          const pages: string[] = [];
 
-        const outputs: string[] = [];
-        const sortedPages = [...selectedPages].sort((a, b) => a - b);
-
-        for (const pageNum of sortedPages) {
-          const page = await doc.getPage(pageNum);
-          const viewport = page.getViewport({ scale });
-
-          const canvas = document.createElement("canvas");
-          canvas.width = Math.floor(viewport.width);
-          canvas.height = Math.floor(viewport.height);
-          const canvasCtx = canvas.getContext("2d");
-          if (!canvasCtx) throw new Error("Failed to create canvas 2D context");
-
-          await page.render({ canvasContext: canvasCtx, canvas, viewport })
-            .promise;
-
-          const pngData = await new Promise<Uint8Array>((resolve, reject) => {
-            canvas.toBlob((blob) => {
-              if (!blob) return reject(new Error("Canvas toBlob failed"));
-              blob.arrayBuffer().then((buf) => resolve(new Uint8Array(buf)));
-            }, "image/png");
-          });
-
-          const pagePath = `${resolvedDir}/page-${pageNum}.png`;
-          await ctx.fs.writeFile(pagePath, pngData);
-          outputs.push(
-            `page-${pageNum}.png (${Math.round(pngData.length / 1024)}KB, ${canvas.width}×${canvas.height})`,
-          );
-
-          canvas.width = 0;
-          canvas.height = 0;
-        }
-
-        return {
-          stdout: `Converted ${outputs.length} page(s) from ${doc.numPages} total to ${outDir}/:\n${outputs.map((o) => `  ${o}`).join("\n")}`,
-          stderr: "",
-          exitCode: 0,
-        };
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { stdout: "", stderr: msg, exitCode: 1 };
-      }
-    }),
-};
-
-const docxToText: CustomCommand = {
-  name: "docx-to-text",
-  load: async () =>
-    defineCommand("docx-to-text", async (args, ctx) => {
-      if (args.length < 2) {
-        return {
-          stdout: "",
-          stderr:
-            "Usage: docx-to-text <file> <outfile>\n  file    - Path to DOCX file in VFS\n  outfile - Output text file\n",
-          exitCode: 1,
-        };
-      }
-
-      const [filePath, outFile] = args;
-
-      try {
-        const data = await resolveVfsPath(ctx, filePath);
-        const mammoth = await import("mammoth");
-        const ab = data.buffer.slice(
-          data.byteOffset,
-          data.byteOffset + data.byteLength,
-        );
-        const bufferCtor = (
-          globalThis as typeof globalThis & {
-            Buffer?: { from(input: ArrayBuffer): unknown };
-          }
-        ).Buffer;
-        const options: Record<string, unknown> = {
-          arrayBuffer: ab,
-        };
-        if (bufferCtor) {
-          options.buffer = bufferCtor.from(ab);
-        }
-        const result = await mammoth.extractRawText(
-          options as unknown as Parameters<typeof mammoth.extractRawText>[0],
-        );
-
-        await writeVfsOutput(ctx, outFile, result.value);
-
-        return {
-          stdout: `Extracted text from DOCX to ${outFile} (${result.value.length} chars)`,
-          stderr: "",
-          exitCode: 0,
-        };
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { stdout: "", stderr: msg, exitCode: 1 };
-      }
-    }),
-};
-
-const xlsxToCsv: CustomCommand = {
-  name: "xlsx-to-csv",
-  load: async () =>
-    defineCommand("xlsx-to-csv", async (args, ctx) => {
-      if (args.length < 2) {
-        return {
-          stdout: "",
-          stderr:
-            "Usage: xlsx-to-csv <file> <outfile> [sheet]\n  file    - Path to XLSX/XLS/ODS file in VFS\n  outfile - Output CSV file (for multiple sheets: <name>.<sheet>.csv)\n  sheet   - Sheet name or 0-based index (optional, exports all sheets if omitted)\n",
-          exitCode: 1,
-        };
-      }
-
-      const [filePath, outFile, sheetArg] = args;
-
-      try {
-        const data = await resolveVfsPath(ctx, filePath);
-        const XLSX = await import("xlsx");
-        const workbook = XLSX.read(data, { type: "array" });
-
-        if (sheetArg) {
-          let sheetName: string;
-          if (workbook.SheetNames.includes(sheetArg)) {
-            sheetName = sheetArg;
-          } else {
-            const idx = Number.parseInt(sheetArg, 10);
-            if (
-              !Number.isNaN(idx) &&
-              idx >= 0 &&
-              idx < workbook.SheetNames.length
-            ) {
-              sheetName = workbook.SheetNames[idx];
-            } else {
-              return {
-                stdout: "",
-                stderr: `Sheet not found: ${sheetArg}. Available: ${workbook.SheetNames.join(", ")}`,
-                exitCode: 1,
-              };
-            }
+          for (let i = 1; i <= doc.numPages; i++) {
+            const page = await doc.getPage(i);
+            const content = await page.getTextContent();
+            const text = content.items
+              .filter((item) => "str" in item)
+              .map((item) => (item as { str: string }).str)
+              .join(" ");
+            if (text.trim()) pages.push(text);
           }
 
-          const sheet = workbook.Sheets[sheetName];
-          if (!sheet) {
+          const fullText = pages.join("\n\n");
+          await writeVfsOutput(ctx, outFile, fullText);
+
+          return {
+            stdout: `Extracted text from ${doc.numPages} page(s) to ${outFile} (${fullText.length} chars)`,
+            stderr: "",
+            exitCode: 0,
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return { stdout: "", stderr: msg, exitCode: 1 };
+        }
+      }),
+  },
+};
+
+const pdfToImages: DescribedCommand = {
+  promptSnippet:
+    "- pdf-to-images <file> <outdir> [--scale=N] [--pages=1,3,5-8] — Render PDF pages to PNG images. Use for scanned PDFs where text extraction won't work. Then use read to visually inspect the images.",
+  command: {
+    name: "pdf-to-images",
+    load: async () =>
+      defineCommand("pdf-to-images", async (args, ctx) => {
+        const positional = args.filter((arg) => !arg.startsWith("--"));
+        const scaleArg = args.find((arg) => arg.startsWith("--scale="));
+        const pagesArg = args.find((arg) => arg.startsWith("--pages="));
+
+        if (positional.length < 2) {
+          return {
+            stdout: "",
+            stderr:
+              "Usage: pdf-to-images <file> <outdir> [--scale=N] [--pages=1,3,5-8]\n  file    - Path to PDF file in VFS\n  outdir  - Output directory for PNG images\n  --scale - Render scale factor (default: 2)\n  --pages - Page selection (e.g. 1,3,5-8). Default: all\n",
+            exitCode: 1,
+          };
+        }
+
+        const [filePath, outDir] = positional;
+        const scale = scaleArg ? Number.parseFloat(scaleArg.split("=")[1]) : 2;
+
+        if (Number.isNaN(scale) || scale <= 0 || scale > 5) {
+          return {
+            stdout: "",
+            stderr: "Scale must be between 0 and 5",
+            exitCode: 1,
+          };
+        }
+
+        try {
+          const data = await resolveVfsPath(ctx, filePath);
+          const doc = await loadPdfDocument(data);
+
+          const selectedPages = pagesArg
+            ? parsePageRanges(pagesArg.split("=")[1], doc.numPages)
+            : new Set(Array.from({ length: doc.numPages }, (_, i) => i + 1));
+
+          if (selectedPages.size === 0) {
             return {
               stdout: "",
-              stderr: `Sheet "${sheetName}" not found`,
+              stderr: "No valid pages in selection",
               exitCode: 1,
             };
           }
 
-          const csv = XLSX.utils.sheet_to_csv(sheet);
-          await writeVfsOutput(ctx, outFile, csv);
+          const resolvedDir = resolvePath(ctx.cwd, outDir);
+          try {
+            await ctx.fs.mkdir(resolvedDir, { recursive: true });
+          } catch {
+            // directory may already exist
+          }
+
+          const outputs: string[] = [];
+          const sortedPages = [...selectedPages].sort((a, b) => a - b);
+
+          for (const pageNum of sortedPages) {
+            const page = await doc.getPage(pageNum);
+            const viewport = page.getViewport({ scale });
+
+            const canvas = document.createElement("canvas");
+            canvas.width = Math.floor(viewport.width);
+            canvas.height = Math.floor(viewport.height);
+            const canvasCtx = canvas.getContext("2d");
+            if (!canvasCtx)
+              throw new Error("Failed to create canvas 2D context");
+
+            await page.render({ canvasContext: canvasCtx, canvas, viewport })
+              .promise;
+
+            const pngData = await new Promise<Uint8Array>((resolve, reject) => {
+              canvas.toBlob((blob) => {
+                if (!blob) return reject(new Error("Canvas toBlob failed"));
+                blob.arrayBuffer().then((buf) => resolve(new Uint8Array(buf)));
+              }, "image/png");
+            });
+
+            const pagePath = `${resolvedDir}/page-${pageNum}.png`;
+            await ctx.fs.writeFile(pagePath, pngData);
+            outputs.push(
+              `page-${pageNum}.png (${Math.round(pngData.length / 1024)}KB, ${canvas.width}×${canvas.height})`,
+            );
+
+            canvas.width = 0;
+            canvas.height = 0;
+          }
 
           return {
-            stdout: `Converted sheet "${sheetName}" → ${outFile}`,
+            stdout: `Converted ${outputs.length} page(s) from ${doc.numPages} total to ${outDir}/:\n${outputs.map((o) => `  ${o}`).join("\n")}`,
             stderr: "",
             exitCode: 0,
           };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return { stdout: "", stderr: msg, exitCode: 1 };
         }
+      }),
+  },
+};
 
-        const names = workbook.SheetNames;
-
-        if (names.length === 1) {
-          const csv = XLSX.utils.sheet_to_csv(workbook.Sheets[names[0]]);
-          await writeVfsOutput(ctx, outFile, csv);
+const docxToText: DescribedCommand = {
+  promptSnippet:
+    "- docx-to-text <file> <outfile> — Extract text from DOCX to file.",
+  command: {
+    name: "docx-to-text",
+    load: async () =>
+      defineCommand("docx-to-text", async (args, ctx) => {
+        if (args.length < 2) {
           return {
-            stdout: `Converted sheet "${names[0]}" → ${outFile}`,
-            stderr: "",
-            exitCode: 0,
+            stdout: "",
+            stderr:
+              "Usage: docx-to-text <file> <outfile>\n  file    - Path to DOCX file in VFS\n  outfile - Output text file\n",
+            exitCode: 1,
           };
         }
 
-        const dotIdx = outFile.lastIndexOf(".");
-        const base = dotIdx > 0 ? outFile.substring(0, dotIdx) : outFile;
-        const ext = dotIdx > 0 ? outFile.substring(dotIdx) : ".csv";
-        const outputs: string[] = [];
+        const [filePath, outFile] = args;
 
-        for (const name of names) {
-          const sheet = workbook.Sheets[name];
-          if (!sheet) continue;
-          const csv = XLSX.utils.sheet_to_csv(sheet);
-          const safeName = name.replace(/[/\\?*[\]]/g, "_");
-          const path = `${base}.${safeName}${ext}`;
-          await writeVfsOutput(ctx, path, csv);
-          outputs.push(`  "${name}" → ${path}`);
+        try {
+          const data = await resolveVfsPath(ctx, filePath);
+          const mammoth = await import("mammoth");
+          const ab = data.buffer.slice(
+            data.byteOffset,
+            data.byteOffset + data.byteLength,
+          );
+          const bufferCtor = (
+            globalThis as typeof globalThis & {
+              Buffer?: { from(input: ArrayBuffer): unknown };
+            }
+          ).Buffer;
+          const options: Record<string, unknown> = {
+            arrayBuffer: ab,
+          };
+          if (bufferCtor) {
+            options.buffer = bufferCtor.from(ab);
+          }
+          const result = await mammoth.extractRawText(
+            options as unknown as Parameters<typeof mammoth.extractRawText>[0],
+          );
+
+          await writeVfsOutput(ctx, outFile, result.value);
+
+          return {
+            stdout: `Extracted text from DOCX to ${outFile} (${result.value.length} chars)`,
+            stderr: "",
+            exitCode: 0,
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return { stdout: "", stderr: msg, exitCode: 1 };
+        }
+      }),
+  },
+};
+
+const xlsxToCsv: DescribedCommand = {
+  promptSnippet:
+    "- xlsx-to-csv <file> <outfile> [sheet] — Convert XLSX/XLS/ODS sheet to CSV. Sheet by name or 0-based index.",
+  command: {
+    name: "xlsx-to-csv",
+    load: async () =>
+      defineCommand("xlsx-to-csv", async (args, ctx) => {
+        if (args.length < 2) {
+          return {
+            stdout: "",
+            stderr:
+              "Usage: xlsx-to-csv <file> <outfile> [sheet]\n  file    - Path to XLSX/XLS/ODS file in VFS\n  outfile - Output CSV file (for multiple sheets: <name>.<sheet>.csv)\n  sheet   - Sheet name or 0-based index (optional, exports all sheets if omitted)\n",
+            exitCode: 1,
+          };
         }
 
+        const [filePath, outFile, sheetArg] = args;
+
+        try {
+          const data = await resolveVfsPath(ctx, filePath);
+          const XLSX = await import("xlsx");
+          const workbook = XLSX.read(data, { type: "array" });
+
+          if (sheetArg) {
+            let sheetName: string;
+            if (workbook.SheetNames.includes(sheetArg)) {
+              sheetName = sheetArg;
+            } else {
+              const idx = Number.parseInt(sheetArg, 10);
+              if (
+                !Number.isNaN(idx) &&
+                idx >= 0 &&
+                idx < workbook.SheetNames.length
+              ) {
+                sheetName = workbook.SheetNames[idx];
+              } else {
+                return {
+                  stdout: "",
+                  stderr: `Sheet not found: ${sheetArg}. Available: ${workbook.SheetNames.join(", ")}`,
+                  exitCode: 1,
+                };
+              }
+            }
+
+            const sheet = workbook.Sheets[sheetName];
+            if (!sheet) {
+              return {
+                stdout: "",
+                stderr: `Sheet "${sheetName}" not found`,
+                exitCode: 1,
+              };
+            }
+
+            const csv = XLSX.utils.sheet_to_csv(sheet);
+            await writeVfsOutput(ctx, outFile, csv);
+
+            return {
+              stdout: `Converted sheet "${sheetName}" → ${outFile}`,
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+
+          const names = workbook.SheetNames;
+
+          if (names.length === 1) {
+            const csv = XLSX.utils.sheet_to_csv(workbook.Sheets[names[0]]);
+            await writeVfsOutput(ctx, outFile, csv);
+            return {
+              stdout: `Converted sheet "${names[0]}" → ${outFile}`,
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+
+          const dotIdx = outFile.lastIndexOf(".");
+          const base = dotIdx > 0 ? outFile.substring(0, dotIdx) : outFile;
+          const ext = dotIdx > 0 ? outFile.substring(dotIdx) : ".csv";
+          const outputs: string[] = [];
+
+          for (const name of names) {
+            const sheet = workbook.Sheets[name];
+            if (!sheet) continue;
+            const csv = XLSX.utils.sheet_to_csv(sheet);
+            const safeName = name.replace(/[/\\?*[\]]/g, "_");
+            const path = `${base}.${safeName}${ext}`;
+            await writeVfsOutput(ctx, path, csv);
+            outputs.push(`  "${name}" → ${path}`);
+          }
+
+          return {
+            stdout: `Converted ${names.length} sheets:\n${outputs.join("\n")}`,
+            stderr: "",
+            exitCode: 0,
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          return { stdout: "", stderr: msg, exitCode: 1 };
+        }
+      }),
+  },
+};
+
+const webSearchCmd: DescribedCommand = {
+  promptSnippet:
+    "- web-search <query> [--max=N] [--region=REGION] [--time=d|w|m|y] [--page=N] [--json] — Search the web. Returns title, URL, and snippet for each result.",
+  command: defineCommand("web-search", async (args) => {
+    const { flags, positional } = parseFlags(args);
+    const query = positional.join(" ");
+
+    if (!query) {
+      return {
+        stdout: "",
+        stderr:
+          "Usage: web-search <query> [--max=N] [--region=REGION] [--time=d|w|m|y] [--page=N] [--json]\n  query    - Search query\n  --max    - Max results (default: 10)\n  --region - Region code, e.g. us-en, uk-en (default: us-en)\n  --time   - Time filter: d(ay), w(eek), m(onth), y(ear)\n  --page   - Page number (default: 1)\n  --json   - Output as JSON\n",
+        exitCode: 1,
+      };
+    }
+
+    try {
+      const webConfig = loadWebConfig();
+      const results = await searchWeb(
+        query,
+        {
+          maxResults: flags.max ? Number.parseInt(flags.max, 10) : 10,
+          region: flags.region,
+          timelimit: flags.time as "d" | "w" | "m" | "y" | undefined,
+          page: flags.page ? Number.parseInt(flags.page, 10) : undefined,
+        },
+        {
+          proxyUrl: getProxyUrl(),
+          apiKeys: webConfig.apiKeys,
+        },
+        webConfig.searchProvider,
+      );
+
+      if (results.length === 0) {
+        return { stdout: "No results found.", stderr: "", exitCode: 0 };
+      }
+
+      if (flags.json === "true") {
         return {
-          stdout: `Converted ${names.length} sheets:\n${outputs.join("\n")}`,
+          stdout: JSON.stringify(results, null, 2),
           stderr: "",
           exitCode: 0,
         };
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return { stdout: "", stderr: msg, exitCode: 1 };
       }
-    }),
+
+      const lines = results.map(
+        (result, index) =>
+          `${index + 1}. ${result.title}\n   ${result.href}\n   ${result.body}`,
+      );
+      return {
+        stdout: lines.join("\n\n"),
+        stderr: "",
+        exitCode: 0,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { stdout: "", stderr: msg, exitCode: 1 };
+    }
+  }),
 };
 
-const webSearchCmd: Command = defineCommand("web-search", async (args) => {
-  const { flags, positional } = parseFlags(args);
-  const query = positional.join(" ");
+const webFetchCmd: DescribedCommand = {
+  promptSnippet:
+    "- web-fetch <url> <outfile> — Fetch a web page and extract its readable content to a file. Use head/grep/tail to read selectively.",
+  command: defineCommand("web-fetch", async (args, ctx) => {
+    const url = args[0];
+    const outFile = args[1];
 
-  if (!query) {
-    return {
-      stdout: "",
-      stderr:
-        "Usage: web-search <query> [--max=N] [--region=REGION] [--time=d|w|m|y] [--page=N] [--json]\n  query    - Search query\n  --max    - Max results (default: 10)\n  --region - Region code, e.g. us-en, uk-en (default: us-en)\n  --time   - Time filter: d(ay), w(eek), m(onth), y(ear)\n  --page   - Page number (default: 1)\n  --json   - Output as JSON\n",
-      exitCode: 1,
-    };
-  }
-
-  try {
-    const webConfig = loadWebConfig();
-    const results = await searchWeb(
-      query,
-      {
-        maxResults: flags.max ? Number.parseInt(flags.max, 10) : 10,
-        region: flags.region,
-        timelimit: flags.time as "d" | "w" | "m" | "y" | undefined,
-        page: flags.page ? Number.parseInt(flags.page, 10) : undefined,
-      },
-      {
-        proxyUrl: getProxyUrl(),
-        apiKeys: webConfig.apiKeys,
-      },
-      webConfig.searchProvider,
-    );
-
-    if (results.length === 0) {
-      return { stdout: "No results found.", stderr: "", exitCode: 0 };
-    }
-
-    if (flags.json === "true") {
+    if (!url || !outFile) {
       return {
-        stdout: JSON.stringify(results, null, 2),
-        stderr: "",
-        exitCode: 0,
+        stdout: "",
+        stderr:
+          "Usage: web-fetch <url> <outfile>\n  url      - URL to fetch\n  outfile  - Output file path\n\nFetches a URL and saves to a file.\n  - HTML pages: extracts readable content (Markdown)\n  - Binary files (PDF, DOCX, XLSX, etc.): downloads raw file\n  - Text/JSON/XML: saves as-is\n",
+        exitCode: 1,
       };
     }
 
-    const lines = results.map(
-      (result, index) =>
-        `${index + 1}. ${result.title}\n   ${result.href}\n   ${result.body}`,
-    );
-    return {
-      stdout: lines.join("\n\n"),
-      stderr: "",
-      exitCode: 0,
-    };
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    return { stdout: "", stderr: msg, exitCode: 1 };
-  }
-});
+    try {
+      const webConfig = loadWebConfig();
+      const result = await fetchWeb(
+        url,
+        {
+          proxyUrl: getProxyUrl(),
+          apiKeys: webConfig.apiKeys,
+        },
+        webConfig.fetchProvider,
+      );
 
-const webFetchCmd: Command = defineCommand("web-fetch", async (args, ctx) => {
-  const url = args[0];
-  const outFile = args[1];
+      if (result.kind === "text") {
+        const header = [
+          result.title ? `Title: ${result.title}` : "",
+          ...Object.entries(result.metadata || {}).map(
+            ([key, value]) => `${key}: ${value}`,
+          ),
+        ]
+          .filter(Boolean)
+          .join("\n");
+        const output = header ? `${header}\n\n${result.text}` : result.text;
 
-  if (!url || !outFile) {
-    return {
-      stdout: "",
-      stderr:
-        "Usage: web-fetch <url> <outfile>\n  url      - URL to fetch\n  outfile  - Output file path\n\nFetches a URL and saves to a file.\n  - HTML pages: extracts readable content (Markdown)\n  - Binary files (PDF, DOCX, XLSX, etc.): downloads raw file\n  - Text/JSON/XML: saves as-is\n",
-      exitCode: 1,
-    };
-  }
+        await writeVfsOutput(ctx, outFile, output);
+        return {
+          stdout: `Fetched text → ${outFile} (${result.text.length} chars, ${result.contentType})`,
+          stderr: "",
+          exitCode: 0,
+        };
+      }
 
-  try {
-    const webConfig = loadWebConfig();
-    const result = await fetchWeb(
-      url,
-      {
-        proxyUrl: getProxyUrl(),
-        apiKeys: webConfig.apiKeys,
-      },
-      webConfig.fetchProvider,
-    );
+      await writeVfsOutput(ctx, outFile, result.data);
 
-    if (result.kind === "text") {
-      const header = [
-        result.title ? `Title: ${result.title}` : "",
-        ...Object.entries(result.metadata || {}).map(
-          ([key, value]) => `${key}: ${value}`,
-        ),
-      ]
-        .filter(Boolean)
-        .join("\n");
-      const output = header ? `${header}\n\n${result.text}` : result.text;
+      const size =
+        result.data.length >= 1024
+          ? `${Math.round(result.data.length / 1024)}KB`
+          : `${result.data.length}B`;
 
-      await writeVfsOutput(ctx, outFile, output);
       return {
-        stdout: `Fetched text → ${outFile} (${result.text.length} chars, ${result.contentType})`,
+        stdout: `Downloaded → ${outFile} (${size}, ${result.contentType || "unknown type"})`,
         stderr: "",
         exitCode: 0,
       };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { stdout: "", stderr: msg, exitCode: 1 };
     }
+  }),
+};
 
-    await writeVfsOutput(ctx, outFile, result.data);
-
-    const size =
-      result.data.length >= 1024
-        ? `${Math.round(result.data.length / 1024)}KB`
-        : `${result.data.length}B`;
-
-    return {
-      stdout: `Downloaded → ${outFile} (${size}, ${result.contentType || "unknown type"})`,
-      stderr: "",
-      exitCode: 0,
-    };
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    return { stdout: "", stderr: msg, exitCode: 1 };
-  }
-});
-
-const imageSearchCmd: Command = defineCommand("image-search", async (args) => {
-  const { flags, positional } = parseFlags(args);
-  const query = positional.join(" ");
-
-  if (!query) {
-    return {
-      stdout: "",
-      stderr:
-        "Usage: image-search <query> [--num=N] [--page=N] [--gl=COUNTRY] [--hl=LANG] [--json]\n" +
-        "  query  - Image search query\n" +
-        "  --num  - Number of results (default: 10)\n" +
-        "  --page - Page number (default: 1)\n" +
-        "  --gl   - Country code, e.g. us, uk (default: us)\n" +
-        "  --hl   - Language code, e.g. en, fr (default: en)\n" +
-        "  --json - Output as JSON\n" +
-        "\nRequires a Serper API key configured in Settings > Web > API Keys.\n",
-      exitCode: 1,
-    };
-  }
-
-  try {
+const imageSearchCmd: DescribedCommand = {
+  promptSnippet:
+    "- image-search <query> [--num=N] [--page=N] [--gl=COUNTRY] [--hl=LANG] [--json] — Search for images. Returns image URLs, dimensions, source, and page link.",
+  isAvailable: () => {
     const webConfig = loadWebConfig();
-    const results = await searchImages(
-      query,
-      {
-        num: flags.num ? Number.parseInt(flags.num, 10) : undefined,
-        page: flags.page ? Number.parseInt(flags.page, 10) : undefined,
-        gl: flags.gl,
-        hl: flags.hl,
-      },
-      {
-        proxyUrl: getProxyUrl(),
-        apiKeys: webConfig.apiKeys,
-      },
-      webConfig.imageSearchProvider,
-    );
+    return !!webConfig.apiKeys?.serper;
+  },
+  command: defineCommand("image-search", async (args) => {
+    const { flags, positional } = parseFlags(args);
+    const query = positional.join(" ");
 
-    if (results.length === 0) {
-      return { stdout: "No images found.", stderr: "", exitCode: 0 };
-    }
-
-    if (flags.json === "true") {
+    if (!query) {
       return {
-        stdout: JSON.stringify(results, null, 2),
-        stderr: "",
-        exitCode: 0,
+        stdout: "",
+        stderr:
+          "Usage: image-search <query> [--num=N] [--page=N] [--gl=COUNTRY] [--hl=LANG] [--json]\n" +
+          "  query  - Image search query\n" +
+          "  --num  - Number of results (default: 10)\n" +
+          "  --page - Page number (default: 1)\n" +
+          "  --gl   - Country code, e.g. us, uk (default: us)\n" +
+          "  --hl   - Language code, e.g. en, fr (default: en)\n" +
+          "  --json - Output as JSON\n" +
+          "\nRequires a Serper API key configured in Settings > Web > API Keys.\n",
+        exitCode: 1,
       };
     }
 
-    const lines = results.map(
-      (result, index) =>
-        `${index + 1}. ${result.title}\n   Image: ${result.imageUrl} (${result.imageWidth}×${result.imageHeight})\n   Source: ${result.source} (${result.domain})\n   Page: ${result.link}`,
-    );
-    return {
-      stdout: lines.join("\n\n"),
-      stderr: "",
-      exitCode: 0,
-    };
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    return { stdout: "", stderr: msg, exitCode: 1 };
-  }
-});
+    try {
+      const webConfig = loadWebConfig();
+      const results = await searchImages(
+        query,
+        {
+          num: flags.num ? Number.parseInt(flags.num, 10) : undefined,
+          page: flags.page ? Number.parseInt(flags.page, 10) : undefined,
+          gl: flags.gl,
+          hl: flags.hl,
+        },
+        {
+          proxyUrl: getProxyUrl(),
+          apiKeys: webConfig.apiKeys,
+        },
+        webConfig.imageSearchProvider,
+      );
+
+      if (results.length === 0) {
+        return { stdout: "No images found.", stderr: "", exitCode: 0 };
+      }
+
+      if (flags.json === "true") {
+        return {
+          stdout: JSON.stringify(results, null, 2),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+
+      const lines = results.map(
+        (result, index) =>
+          `${index + 1}. ${result.title}\n   Image: ${result.imageUrl} (${result.imageWidth}×${result.imageHeight})\n   Source: ${result.source} (${result.domain})\n   Page: ${result.link}`,
+      );
+      return {
+        stdout: lines.join("\n\n"),
+        stderr: "",
+        exitCode: 0,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { stdout: "", stderr: msg, exitCode: 1 };
+    }
+  }),
+};
+
+export interface CustomCommandsResult {
+  commands: CustomCommand[];
+  promptSnippets: string[];
+}
+
+function collect(described: DescribedCommand[]): CustomCommandsResult {
+  const availableSnippets = described.filter(
+    (d) => !d.isAvailable || d.isAvailable(),
+  );
+  return {
+    commands: described.map((d) => d.command),
+    promptSnippets: availableSnippets.map((d) => d.promptSnippet),
+  };
+}
 
 export function getSharedCustomCommands(
   options: SharedCustomCommandOptions = {},
-): CustomCommand[] {
-  const commands: CustomCommand[] = [
+): CustomCommandsResult {
+  const all: DescribedCommand[] = [
     pdfToText,
     pdfToImages,
     docxToText,
@@ -542,8 +596,8 @@ export function getSharedCustomCommands(
   ];
 
   if (options.includeImageSearch) {
-    commands.push(imageSearchCmd);
+    all.push(imageSearchCmd);
   }
 
-  return commands;
+  return collect(all);
 }

--- a/packages/sdk/src/vfs/index.ts
+++ b/packages/sdk/src/vfs/index.ts
@@ -10,7 +10,11 @@
 import { Bash, type CustomCommand, InMemoryFs } from "just-bash/browser";
 
 export { parseFlags, parsePageRanges } from "./command-utils";
-export { getSharedCustomCommands } from "./custom-commands";
+export {
+  getSharedCustomCommands,
+  type CustomCommandsResult,
+  type DescribedCommand,
+} from "./custom-commands";
 
 let fs: InMemoryFs | null = null;
 let bash: Bash | null = null;

--- a/packages/sdk/src/vfs/index.ts
+++ b/packages/sdk/src/vfs/index.ts
@@ -11,9 +11,9 @@ import { Bash, type CustomCommand, InMemoryFs } from "just-bash/browser";
 
 export { parseFlags, parsePageRanges } from "./command-utils";
 export {
-  getSharedCustomCommands,
   type CustomCommandsResult,
   type DescribedCommand,
+  getSharedCustomCommands,
 } from "./custom-commands";
 
 let fs: InMemoryFs | null = null;

--- a/packages/sdk/tests/custom-commands-integration.test.ts
+++ b/packages/sdk/tests/custom-commands-integration.test.ts
@@ -32,7 +32,7 @@ const hasPromiseTry = typeof Promise.try === "function";
 
 describe("shared custom commands (integration)", () => {
   beforeEach(() => {
-    setCustomCommands(() => getSharedCustomCommands());
+    setCustomCommands(() => getSharedCustomCommands().commands);
     resetVfs();
   });
 

--- a/packages/word/CHANGELOG.md
+++ b/packages/word/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Co-located command prompt snippets** — System prompt assembles command docs dynamically from `DescribedCommand` snippets instead of hard-coding them.
+
 ## [0.0.3] - 2026-03-19
 
 ### Changed

--- a/packages/word/src/lib/system-prompt.ts
+++ b/packages/word/src/lib/system-prompt.ts
@@ -1,6 +1,10 @@
 import { buildSkillsPromptSection, type SkillMeta } from "@office-agents/core";
 
-export function buildWordSystemPrompt(skills: SkillMeta[]): string {
+export function buildWordSystemPrompt(
+  skills: SkillMeta[],
+  commandSnippets: string[] = [],
+): string {
+  const customCommandsList = commandSnippets.map((s) => `  ${s}`).join("\n");
   return `You are an AI assistant integrated into Microsoft Word with direct Office.js access.
 
 ## Office.js API Reference
@@ -17,13 +21,7 @@ FILES & SHELL:
 - read: Read uploaded files (images, CSV, text). Images are returned for visual analysis.
 - bash: Execute bash commands in a sandboxed virtual filesystem. User uploads are in /home/user/uploads/.
   Custom commands available in bash:
-  - pdf-to-text <file> <outfile> — Extract text from a PDF
-  - pdf-to-images <file> <outdir> [--scale=N] [--pages=1,3,5-8] — Render PDF pages as PNG images
-  - docx-to-text <file> <outfile> — Extract text from a DOCX file
-  - xlsx-to-csv <file> <outfile> [sheet] — Convert XLSX/XLS/ODS to CSV
-  - web-search <query> [--max=N] [--json] — Search the web
-  - web-fetch <url> <outfile> — Fetch a URL (HTML→Markdown, binary→raw file)
-  - image-search <query> [--num=N] [--page=N] [--gl=COUNTRY] [--hl=LANG] [--json] — Search for images. Returns image URLs, dimensions, source, and page link.
+${customCommandsList}
 
 WORD READ:
 - screenshot_document: Visual screenshot of document pages (desktop/Mac only — not available in Word Online). Exports to PDF then renders as images.

--- a/packages/word/src/lib/vfs/custom-commands.ts
+++ b/packages/word/src/lib/vfs/custom-commands.ts
@@ -1,6 +1,12 @@
-import { getSharedCustomCommands } from "@office-agents/core";
-import type { CustomCommand } from "just-bash/browser";
+import {
+  getSharedCustomCommands,
+  type CustomCommandsResult,
+} from "@office-agents/core";
 
-export function getCustomCommands(): CustomCommand[] {
-  return [...getSharedCustomCommands({ includeImageSearch: true })];
+export function getCustomCommands(): CustomCommandsResult {
+  const shared = getSharedCustomCommands({ includeImageSearch: true });
+  return {
+    commands: [...shared.commands],
+    promptSnippets: [...shared.promptSnippets],
+  };
 }

--- a/packages/word/src/lib/vfs/custom-commands.ts
+++ b/packages/word/src/lib/vfs/custom-commands.ts
@@ -1,6 +1,6 @@
 import {
-  getSharedCustomCommands,
   type CustomCommandsResult,
+  getSharedCustomCommands,
 } from "@office-agents/core";
 
 export function getCustomCommands(): CustomCommandsResult {


### PR DESCRIPTION
## Summary
- refactor custom commands to return both executable commands and prompt snippets
- thread command snippets through runtime/app adapters into app system prompts
- update shared/app-specific custom command registration to use `CustomCommandsResult`

## Included
- `DescribedCommand` / `CustomCommandsResult`
- runtime + adapter changes for snippet-aware system prompt generation
- excel / powerpoint / word custom command refactors
- system prompts now render command docs from shared snippets instead of duplicating lists

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run packages/sdk/tests/custom-commands-integration.test.ts`
- `pnpm exec vitest run --environment happy-dom packages/sdk/tests/vfs-custom-commands.test.ts packages/sdk/tests/runtime.test.ts`
- office-bridge smoke test in live Word runtime:
  - `getSharedCustomCommands()` returns `{ commands, promptSnippets }`
  - app `getCustomCommands()` returns `{ commands, promptSnippets }`
  - built Word prompt includes dynamic snippets like `pdf-to-text` / `web-fetch`
  - built Word prompt does not include `browse`

## Notes
This PR intentionally excludes the new browser package and browser UI/settings work, which live in a separate PR.